### PR TITLE
feat: add useColorsPool to addRandomSplats

### DIFF
--- a/packages/lib/src/fluid-animation.js
+++ b/packages/lib/src/fluid-animation.js
@@ -84,11 +84,16 @@ export default class FluidAnimation {
     this._splatStack.push(Array.isArray(splats) ? splats : [splats]);
   }
 
-  addRandomSplats(count) {
+  addRandomSplats(count,useColorsPool=false) {
     const splats = [];
 
     for (let i = 0; i < count; ++i) {
-      splats.push(this._getRandomSplat());
+      if (useColorsPool) {
+        splats.push(this._getRandomSplat(true));
+      } else {
+        splats.push(this._getRandomSplat());
+
+      }
     }
 
     this.addSplats(splats);
@@ -336,8 +341,12 @@ export default class FluidAnimation {
     }
   }
 
-  _getRandomSplat() {
-    const color = [Math.random() * 10, Math.random() * 10, Math.random() * 10];
+  _getRandomSplat(useColorsPool=false) {
+    let color;
+    if (useColorsPool) 
+       color = this.config.colorsPool[Math.floor(Math.random() * this.config.colorsPool.length)]
+    else 
+      color = [Math.random() * 10, Math.random() * 10, Math.random() * 10];
     const x = this._canvas.width * Math.random();
     const y = this._canvas.height * Math.random();
     const dx = 1000 * (Math.random() - 0.5);


### PR DESCRIPTION
## Description

This pull request adds a new feature that allows users to generate random splats with a customizable colors pool. Previously, the user could only generate random splats with random colors that may not match their website theme. 

## Changes

- Added a new parameter "useColorsPool" to the function addRandomSplats, this parameter is optional and by default is false
- Added a new parameter "useColorsPool" to the function _getRandomSplat, this parameter is optional and by default is false

When useColorsPool is true, the color of the random splat belongs to one of the colors of the config

## Implementation
Its use is very simple, now when you call the addRandomSplats function if you want the splats to match your colorsPool config, you can pass a new argument like this:
addRandomSplats(5 + Math.random() * 20 , true);
